### PR TITLE
Fix datadog provider configuration

### DIFF
--- a/src/remote-state.tf
+++ b/src/remote-state.tf
@@ -141,7 +141,7 @@ data "jq_query" "service_domain_query" {
 }
 
 module "datadog_configuration" {
-  source  = "../datadog-configuration/modules/datadog_keys"
+  source  = "github.com/cloudposse-terraform-components/aws-datadog-credentials//src/modules/datadog_keys?ref=tags/v1.535.2"
   enabled = true
   context = module.this.context
 }


### PR DESCRIPTION
## what
* Replace relative path for datadog creds module with git reference to the component

## why
* After we split monorepo we can not use relative paths for component references


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the source location for the Datadog configuration module to use a specific version from a remote repository. No changes to functionality or configuration parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->