### PR TITLE
Bugfix: deprecated params & unused datasource from lookup

### DIFF
--- a/src/datadog-agent.tf
+++ b/src/datadog-agent.tf
@@ -46,12 +46,6 @@ data "aws_ssm_parameter" "datadog_api_key" {
   name = var.datadog_api_key_ssm_parameter_name
 }
 
-data "aws_ssm_parameter" "datadog_app_key" {
-  count = var.datadog_app_key_ssm_parameter_name != null && var.datadog_agent_sidecar_enabled ? 1 : 0
-
-  name = var.datadog_app_key_ssm_parameter_name
-}
-
 locals {
   default_datadog_tags = var.datadog_logging_default_tags_enabled ? {
     env     = module.this.stage

--- a/src/main.tf
+++ b/src/main.tf
@@ -447,14 +447,12 @@ module "ecs_cloudwatch_autoscaling" {
 
   count = local.enabled && var.task_enabled && var.autoscaling_enabled ? 1 : 0
 
-  service_name          = module.ecs_alb_service_task[0].service_name
-  cluster_name          = module.ecs_cluster.outputs.cluster_name
-  min_capacity          = lookup(local.task, "min_capacity", 1)
-  max_capacity          = lookup(local.task, "max_capacity", 2)
-  scale_up_adjustment   = 1
-  scale_up_cooldown     = 60
-  scale_down_adjustment = -1
-  scale_down_cooldown   = 300
+  service_name        = module.ecs_alb_service_task[0].service_name
+  cluster_name        = module.ecs_cluster.outputs.cluster_name
+  min_capacity        = lookup(local.task, "min_capacity", 1)
+  max_capacity        = lookup(local.task, "max_capacity", 2)
+  scale_up_cooldown   = 60
+  scale_down_cooldown = 300
 
   context = module.this.context
 


### PR DESCRIPTION
## what
* Bugfix:
  * deprecated parameters in module
  * Unused datasource


## why
* Bugfixes for version 2
## references
* #39 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Removed retrieval of the Datadog application key from AWS SSM Parameter Store.
  - Removed unused scaling adjustment parameters from the autoscaling configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->