### PR TITLE
chore(deps): restrict aws provider version to < 6.0.0

### DIFF
--- a/src/versions.tf
+++ b/src/versions.tf
@@ -12,7 +12,7 @@ terraform {
       ## │   with module.ecs_cloudwatch_autoscaling[0].aws_appautoscaling_target.default[0],
       ## │   on .terraform/modules/ecs_cloudwatch_autoscaling/main.tf line 15, in resource "aws_appautoscaling_target" "default":
       ## │   15: resource "aws_appautoscaling_target" "default" {
-      version = ">= 4.66.1"
+      version = ">= 4.66.1, < 6.0.0"
     }
     template = {
       source  = "cloudposse/template"


### PR DESCRIPTION
This pull request includes a version constraint update for the AWS provider in the Terraform configuration file `src/versions.tf`. The change ensures compatibility with versions up to but not including 6.0.0.

* `src/versions.tf`: Updated the version constraint for the `aws` provider to `>= 4.9.0, < 6.0.0` to ensure compatibility with future versions while avoiding potential breaking changes in version 6.0.0.