### PR TITLE
Map Secrets support Forward Slashes

### DIFF
--- a/src/main.tf
+++ b/src/main.tf
@@ -175,9 +175,13 @@ locals {
   }
   map_secrets = { for k, v in local.containers_priority_terraform : k => lookup(v, "map_secrets", null) != null ? zipmap(
     keys(lookup(v, "map_secrets", null)),
-    formatlist("%s%s", format("arn:aws:ssm:%s:%s:parameter", var.region, module.roles_to_principals.full_account_map[format("%s-%s", var.tenant, var.stage)]),
-      [for value in values(lookup(v, "map_secrets", null)) : startswith(value, "/") ? value : format("/%s", value)]
-    )
+    [for value in values(lookup(v, "map_secrets", null)) :
+      format(
+        "%s%s",
+        format("arn:aws:ssm:%s:%s:parameter", var.region, module.roles_to_principals.full_account_map[format("%s-%s", var.tenant, var.stage)]),
+        startswith(value, "/") ? value : format("/%s", value)
+      )
+    ]
   ) : null }
 }
 

--- a/src/main.tf
+++ b/src/main.tf
@@ -175,8 +175,9 @@ locals {
   }
   map_secrets = { for k, v in local.containers_priority_terraform : k => lookup(v, "map_secrets", null) != null ? zipmap(
     keys(lookup(v, "map_secrets", null)),
-    formatlist("%s/%s", format("arn:aws:ssm:%s:%s:parameter", var.region, module.roles_to_principals.full_account_map[format("%s-%s", var.tenant, var.stage)]),
-    values(lookup(v, "map_secrets", null)))
+    formatlist("%s%s", format("arn:aws:ssm:%s:%s:parameter", var.region, module.roles_to_principals.full_account_map[format("%s-%s", var.tenant, var.stage)]),
+      [for value in values(lookup(v, "map_secrets", null)) : startswith(value, "/") ? value : format("/%s", value)]
+    )
   ) : null }
 }
 


### PR DESCRIPTION

## what
* This improves a weird pattern having the map secrets be in the format `foo/bar` when typically in SSM they are `/foo/bar`
* We now support `/foo/bar` and `foo/bar`

## why
* Helps support things like
```
map_secrets:
  FOO: !terraform.state rds .db_user_password_ssm_key
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of secret parameter paths to ensure correct formatting and prevent duplicate or missing slashes in AWS SSM Parameter Store ARNs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->