### PR TITLE
Allow users to set component names in remote state

### DIFF
--- a/src/remote-state.tf
+++ b/src/remote-state.tf
@@ -57,7 +57,7 @@ module "vpc" {
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
   version = "1.8.0"
 
-  component = "vpc"
+  component = var.vpc_component_name
 
   context = module.this.context
 }

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -707,3 +707,9 @@ variable "scale_down_step_adjustments" {
     scaling_adjustment          = -1
   }]
 }
+
+variable "vpc_component_name" {
+  type        = string
+  description = "The name of a VPC component"
+  default     = "vpc"
+}


### PR DESCRIPTION
Allow users to set component names in remote state.

* Defined input variables `vpc_component_name`.
* Variable defaults to preserving the behaviour of the current version.
* Remote state uses this variable to pull in the state of the components.
* This update allows the codebase to adopt more standardized structure and naming practices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable option to set the VPC component name through a new variable, allowing greater flexibility in naming.
* **Chores**
  * Updated configuration to use the new variable for the VPC component name instead of a fixed value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->