### PR TITLE
bugfix: Conditional with inconsistent types

### DIFF
--- a/src/main.tf
+++ b/src/main.tf
@@ -605,7 +605,7 @@ data "aws_ecs_task_definition" "created_task" {
 }
 
 locals {
-  created_task_definition = local.s3_mirroring_enabled ? data.aws_ecs_task_definition.created_task[0] : {}
+  created_task_definition = local.s3_mirroring_enabled ? data.aws_ecs_task_definition.created_task[0] : null
   task_template = local.s3_mirroring_enabled ? {
     containerDefinitions = local.container_definition
     family               = lookup(local.created_task_definition, "family", null),


### PR DESCRIPTION
## what
* Small bugfix when s3 mirroring is enabled.

## why
* Inconsistent types error.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved handling of disabled S3 mirroring by assigning `null` values instead of empty maps to certain settings, ensuring safer configuration references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->