### PR TITLE
Support user pass through

### DIFF
--- a/src/main.tf
+++ b/src/main.tf
@@ -233,6 +233,7 @@ module "container_definition" {
   docker_labels        = each.value["docker_labels"]
   container_depends_on = each.value["container_depends_on"]
   privileged           = each.value["privileged"]
+  user                 = each.value["user"]
 
   log_configuration = try(lookup(lookup(each.value, "log_configuration", {}), "logDriver", {}), "awslogs") == "awslogs" ? merge(lookup(each.value, "log_configuration", {}), {
     logDriver = "awslogs"
@@ -340,6 +341,7 @@ module "ecs_alb_service_task" {
   ecs_service_enabled                = lookup(local.task, "ecs_service_enabled", true)
   task_role_arn                      = lookup(local.task, "task_role_arn", one(module.iam_role[*]["outputs"]["role"]["arn"]))
   capacity_provider_strategies       = lookup(local.task, "capacity_provider_strategies")
+  user                               = lookup(local.task, "user", null)
 
   task_exec_policy_arns_map = var.task_exec_policy_arns_map
 

--- a/src/main.tf
+++ b/src/main.tf
@@ -341,7 +341,6 @@ module "ecs_alb_service_task" {
   ecs_service_enabled                = lookup(local.task, "ecs_service_enabled", true)
   task_role_arn                      = lookup(local.task, "task_role_arn", one(module.iam_role[*]["outputs"]["role"]["arn"]))
   capacity_provider_strategies       = lookup(local.task, "capacity_provider_strategies")
-  user                               = lookup(local.task, "user", null)
 
   task_exec_policy_arns_map = var.task_exec_policy_arns_map
 

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -56,6 +56,7 @@ variable "containers" {
     essential                = optional(bool, true)
     readonly_root_filesystem = optional(bool, null)
     privileged               = optional(bool, null)
+    user                     = optional(string, null)
     container_depends_on = optional(list(object({
       containerName = string
       condition     = string # START, COMPLETE, SUCCESS, HEALTHY

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -100,7 +100,10 @@ variable "containers" {
       readOnly      = optional(bool)
     })), [])
   }))
-  description = "Feed inputs into container definition module"
+  description = <<EOT
+Inputs for the container definition module.
+`user`: The user to run as inside the container. Can be any of these formats: user, user:group, uid, uid:gid, user:gid, uid:group. The default (null) will use the container's configured `USER` directive or root if not set."
+EOT
   default     = {}
 }
 


### PR DESCRIPTION
This pull request introduces a new `user` property to the container definition module in Terraform, allowing users to specify the user context under which a container runs. The changes include updates to the module's configuration and its input variables to support this new property.

### Support for `user` property in container definitions:

* **`src/main.tf`:** Added the `user` property to the `container_definition` module, enabling the specification of the user context for containers.

* **`src/variables.tf`:**
  * Declared the `user` variable as an optional string in the `containers` variable definition.
  * Updated the description of the `containers` variable to document the `user` property, explaining its purpose and accepted formats.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for specifying the user under which containers run, allowing configuration of user, group, or ID formats.

* **Documentation**
  * Updated variable descriptions to document the new user attribute for container configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->