### PR TITLE
Bugfix: Main.tf expects both values

### DIFF
--- a/src/main.tf
+++ b/src/main.tf
@@ -368,13 +368,13 @@ resource "aws_security_group_rule" "custom_sg_rules" {
     format("%s_%s_%s", sg_rule.protocol, sg_rule.from_port, sg_rule.to_port) => sg_rule
   } : {}
 
-  description              = each.value.description
+  description              = try(each.value.description, null)
   type                     = each.value.type
   from_port                = each.value.from_port
   to_port                  = each.value.to_port
   protocol                 = each.value.protocol
-  cidr_blocks              = each.value.cidr_blocks
-  source_security_group_id = each.value.source_security_group_id
+  cidr_blocks              = try(each.value.cidr_blocks, null)
+  source_security_group_id = try(each.value.source_security_group_id, null)
   security_group_id        = one(module.ecs_alb_service_task[*].service_security_group_id)
 }
 


### PR DESCRIPTION
## what
* Follow up to #62 

## why
* Main.tf expects both values present despite variables.tf making them optional. 
* The other path would've been to make the optional variables have a default value.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Security group rule inputs now handle missing values gracefully, preventing errors when optional fields aren’t provided.
  - Optional fields (e.g., descriptions, CIDR blocks, or source group references) can be omitted without causing failures.
  - Improves stability when defining minimal security group rules without extra attributes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->