### PR TITLE
replace local.nlb with local.nlb.nlb

### DIFF
--- a/src/main.tf
+++ b/src/main.tf
@@ -385,7 +385,7 @@ module "alb_ingress" {
   count = local.is_alb ? 1 : 0
 
   vpc_id                        = local.vpc_id
-  unauthenticated_listener_arns = [local.lb_listener_https_arn]
+  unauthenticated_listener_arns = compact([local.lb_listener_https_arn])
   unauthenticated_hosts = var.lb_catch_all ? [format("*.%s", var.vanity_domain), local.full_domain] : concat([
     local.full_domain
   ], var.vanity_alias, var.additional_targets)
@@ -472,12 +472,12 @@ module "vanity_alias" {
   source  = "cloudposse/route53-alias/aws"
   version = "0.13.0"
 
-  count = local.enabled && local.lb_zone_id_or_null != null ? 1 : 0
+  count = local.enabled && local.lb_zone_id != null ? 1 : 0
 
   aliases         = var.vanity_alias
   parent_zone_id  = local.vanity_domain_zone_id
   target_dns_name = local.lb_name
-  target_zone_id  = local.lb_zone_id_or_null
+  target_zone_id  = local.lb_zone_id
 
   context = module.this.context
 }

--- a/src/main.tf
+++ b/src/main.tf
@@ -472,12 +472,12 @@ module "vanity_alias" {
   source  = "cloudposse/route53-alias/aws"
   version = "0.13.0"
 
-  count = local.enabled && local.lb_zone_id != null ? 1 : 0
+  count = local.enabled && local.lb_zone_id_or_null != null ? 1 : 0
 
   aliases         = var.vanity_alias
   parent_zone_id  = local.vanity_domain_zone_id
   target_dns_name = local.lb_name
-  target_zone_id  = local.lb_zone_id
+  target_zone_id  = local.lb_zone_id_or_null
 
   context = module.this.context
 }

--- a/src/main.tf
+++ b/src/main.tf
@@ -314,7 +314,7 @@ module "ecs_alb_service_task" {
     {
       container_name   = try(local.service_container["name"], null),
       container_port   = local.container_port,
-      target_group_arn = local.is_alb ? module.alb_ingress[0].target_group_arn : local.nlb.default_target_group_arn
+      target_group_arn = local.is_alb ? module.alb_ingress[0].target_group_arn : local.nlb.nlb.default_target_group_arn
       # not required since elb is unused but must be set to null
       elb_name = null
     },

--- a/src/main.tf
+++ b/src/main.tf
@@ -314,7 +314,7 @@ module "ecs_alb_service_task" {
     {
       container_name   = try(local.service_container["name"], null),
       container_port   = local.container_port,
-      target_group_arn = local.is_alb ? module.alb_ingress[0].target_group_arn : local.nlb.nlb.default_target_group_arn
+      target_group_arn = local.is_alb ? module.alb_ingress[0].target_group_arn : local.nlb_compat.default_target_group_arn
       # not required since elb is unused but must be set to null
       elb_name = null
     },

--- a/src/main.tf
+++ b/src/main.tf
@@ -472,7 +472,7 @@ module "vanity_alias" {
   source  = "cloudposse/route53-alias/aws"
   version = "0.13.0"
 
-  count = local.enabled ? 1 : 0
+  count = local.enabled && local.lb_zone_id != null ? 1 : 0
 
   aliases         = var.vanity_alias
   parent_zone_id  = local.vanity_domain_zone_id

--- a/src/remote-state.tf
+++ b/src/remote-state.tf
@@ -43,7 +43,7 @@ locals {
     try(local.alb.alb_zone_id, null),
     "",
   )
-  lb_zone_id = local.lb_zone_id == "" ? null : local.lb_zone_id
+  lb_zone_id_or_null = local.lb_zone_id == "" ? null : local.lb_zone_id
 
   lb_fqdn = coalesce(
     try(local.nlb_compat.route53_record.fqdn, null),

--- a/src/remote-state.tf
+++ b/src/remote-state.tf
@@ -16,16 +16,16 @@ locals {
   use_lb = local.enabled && var.use_lb
 
   requested_protocol = local.use_lb && !local.lb_listener_http_is_redirect ? var.http_protocol : null
-  lb_protocol        = local.lb_listener_http_is_redirect || try(local.is_nlb && local.nlb.is_443_enabled, false) ? "https" : "http"
+  lb_protocol        = local.lb_listener_http_is_redirect || try(local.is_nlb && local.nlb.nlb.is_443_enabled, false) ? "https" : "http"
   http_protocol      = coalesce(local.requested_protocol, local.lb_protocol)
 
-  lb_arn                       = try(coalesce(local.nlb.nlb_arn, ""), coalesce(local.alb.alb_arn, ""), null)
-  lb_name                      = try(coalesce(local.nlb.nlb_name, ""), coalesce(local.alb.alb_dns_name, ""), null)
+  lb_arn                       = try(coalesce(local.nlb.nlb.nlb_arn, ""), coalesce(local.alb.alb_arn, ""), null)
+  lb_name                      = try(coalesce(local.nlb.nlb.nlb_name, ""), coalesce(local.alb.alb_dns_name, ""), null)
   lb_listener_http_is_redirect = try(length(local.is_nlb ? "" : local.alb.http_redirect_listener_arn) > 0, false)
-  lb_listener_https_arn        = try(coalesce(local.nlb.default_listener_arn, ""), coalesce(local.alb.https_listener_arn, ""), null)
+  lb_listener_https_arn        = try(coalesce(local.nlb.nlb.default_listener_arn, ""), coalesce(local.alb.https_listener_arn, ""), null)
   lb_sg_id                     = try(local.is_nlb ? null : local.alb.security_group_id, null)
-  lb_zone_id                   = try(coalesce(local.nlb.nlb_zone_id, ""), coalesce(local.alb.alb_zone_id, ""), null)
-  lb_fqdn                      = try(coalesce(local.nlb.route53_record.fqdn, ""), coalesce(local.alb.route53_record.fqdn, ""), local.full_domain)
+  lb_zone_id                   = try(coalesce(local.nlb.nlb.nlb_zone_id, ""), coalesce(local.alb.alb_zone_id, ""), null)
+  lb_fqdn                      = try(coalesce(local.nlb.nlb.route53_record.fqdn, ""), coalesce(local.alb.route53_record.fqdn, ""), local.full_domain)
 
 }
 

--- a/src/remote-state.tf
+++ b/src/remote-state.tf
@@ -13,17 +13,8 @@ locals {
   is_nlb = local.use_lb && try(length(var.nlb_name) > 0, false)
   nlb    = try(module.nlb[0].outputs, null)
 
-  # Backward compatibility for nlb outputs - support both old format (local.nlb.property) and new format (local.nlb.nlb.property)
-  nlb_compat = local.nlb != null ? {
-    nlb_arn                  = try(local.nlb.nlb.nlb_arn, local.nlb.nlb_arn, null)
-    nlb_name                 = try(local.nlb.nlb.nlb_name, local.nlb.nlb_name, null)
-    nlb_dns_name             = try(local.nlb.nlb.nlb_dns_name, local.nlb.nlb_dns_name, null)
-    nlb_zone_id              = try(local.nlb.nlb.nlb_zone_id, local.nlb.nlb_zone_id, null)
-    default_listener_arn     = try(local.nlb.nlb.default_listener_arn, local.nlb.default_listener_arn, null)
-    default_target_group_arn = try(local.nlb.nlb.default_target_group_arn, local.nlb.default_target_group_arn, null)
-    is_443_enabled           = try(local.nlb.nlb.is_443_enabled, local.nlb.is_443_enabled, false)
-    route53_record           = try(local.nlb.nlb.route53_record, local.nlb.route53_record, {})
-  } : null
+  # Backward compatibility for NLB outputs — prefer new nested form (`local.nlb.nlb`) with fallback to old flat form (`local.nlb`).
+  nlb_compat = try(local.nlb.nlb, local.nlb)
 
   use_lb = local.enabled && var.use_lb
 

--- a/src/remote-state.tf
+++ b/src/remote-state.tf
@@ -15,14 +15,14 @@ locals {
 
   # Backward compatibility for nlb outputs - support both old format (local.nlb.property) and new format (local.nlb.nlb.property)
   nlb_compat = local.nlb != null ? {
-    nlb_arn                = try(local.nlb.nlb.nlb_arn, local.nlb.nlb_arn, null)
-    nlb_name               = try(local.nlb.nlb.nlb_name, local.nlb.nlb_name, null)
-    nlb_dns_name           = try(local.nlb.nlb.nlb_dns_name, local.nlb.nlb_dns_name, null)
-    nlb_zone_id            = try(local.nlb.nlb.nlb_zone_id, local.nlb.nlb_zone_id, null)
-    default_listener_arn   = try(local.nlb.nlb.default_listener_arn, local.nlb.default_listener_arn, null)
+    nlb_arn                  = try(local.nlb.nlb.nlb_arn, local.nlb.nlb_arn, null)
+    nlb_name                 = try(local.nlb.nlb.nlb_name, local.nlb.nlb_name, null)
+    nlb_dns_name             = try(local.nlb.nlb.nlb_dns_name, local.nlb.nlb_dns_name, null)
+    nlb_zone_id              = try(local.nlb.nlb.nlb_zone_id, local.nlb.nlb_zone_id, null)
+    default_listener_arn     = try(local.nlb.nlb.default_listener_arn, local.nlb.default_listener_arn, null)
     default_target_group_arn = try(local.nlb.nlb.default_target_group_arn, local.nlb.default_target_group_arn, null)
-    is_443_enabled         = try(local.nlb.nlb.is_443_enabled, local.nlb.is_443_enabled, false)
-    route53_record         = try(local.nlb.nlb.route53_record, local.nlb.route53_record, {})
+    is_443_enabled           = try(local.nlb.nlb.is_443_enabled, local.nlb.is_443_enabled, false)
+    route53_record           = try(local.nlb.nlb.route53_record, local.nlb.route53_record, {})
   } : null
 
   use_lb = local.enabled && var.use_lb
@@ -34,19 +34,19 @@ locals {
   lb_arn                       = try(coalesce(local.nlb_compat.nlb_arn, ""), coalesce(local.alb.alb_arn, ""), null)
   lb_name                      = try(coalesce(local.nlb_compat.nlb_name, ""), coalesce(local.alb.alb_dns_name, ""), null)
   lb_listener_http_is_redirect = try(length(local.is_nlb ? "" : local.alb.http_redirect_listener_arn) > 0, false)
-  lb_listener_https_arn       = coalesce(try(local.nlb_compat.default_listener_arn, null), try(local.alb.https_listener_arn, null), null)
+  lb_listener_https_arn        = coalesce(try(local.nlb_compat.default_listener_arn, null), try(local.alb.https_listener_arn, null), null)
   lb_sg_id                     = try(local.is_nlb ? null : local.alb.security_group_id, null)
   # Replace the try+coalesce("") pattern (which can return "") with
   # coalesce over try(..., null) to properly fall through to the next non-null value
   lb_zone_id = coalesce(
     try(local.nlb_compat.nlb_zone_id, null),
-    try(local.alb.alb_zone_id,      null),
+    try(local.alb.alb_zone_id, null),
     null,
   )
 
-  lb_fqdn    = coalesce(
+  lb_fqdn = coalesce(
     try(local.nlb_compat.route53_record.fqdn, null),
-    try(local.alb.route53_record.fqdn,      null),
+    try(local.alb.route53_record.fqdn, null),
     local.full_domain,
   )
 

--- a/src/remote-state.tf
+++ b/src/remote-state.tf
@@ -17,6 +17,7 @@ locals {
   nlb_compat = local.nlb != null ? {
     nlb_arn                = try(local.nlb.nlb.nlb_arn, local.nlb.nlb_arn, null)
     nlb_name               = try(local.nlb.nlb.nlb_name, local.nlb.nlb_name, null)
+    nlb_dns_name           = try(local.nlb.nlb.nlb_dns_name, local.nlb.nlb_dns_name, null)
     nlb_zone_id            = try(local.nlb.nlb.nlb_zone_id, local.nlb.nlb_zone_id, null)
     default_listener_arn   = try(local.nlb.nlb.default_listener_arn, local.nlb.default_listener_arn, null)
     default_target_group_arn = try(local.nlb.nlb.default_target_group_arn, local.nlb.default_target_group_arn, null)
@@ -33,10 +34,21 @@ locals {
   lb_arn                       = try(coalesce(local.nlb_compat.nlb_arn, ""), coalesce(local.alb.alb_arn, ""), null)
   lb_name                      = try(coalesce(local.nlb_compat.nlb_name, ""), coalesce(local.alb.alb_dns_name, ""), null)
   lb_listener_http_is_redirect = try(length(local.is_nlb ? "" : local.alb.http_redirect_listener_arn) > 0, false)
-  lb_listener_https_arn        = try(coalesce(local.nlb_compat.default_listener_arn, ""), coalesce(local.alb.https_listener_arn, ""), null)
+  lb_listener_https_arn       = coalesce(try(local.nlb_compat.default_listener_arn, null), try(local.alb.https_listener_arn, null), null)
   lb_sg_id                     = try(local.is_nlb ? null : local.alb.security_group_id, null)
-  lb_zone_id                   = try(coalesce(local.nlb_compat.nlb_zone_id, ""), coalesce(local.alb.alb_zone_id, ""), null)
-  lb_fqdn                      = try(coalesce(local.nlb_compat.route53_record.fqdn, ""), coalesce(local.alb.route53_record.fqdn, ""), local.full_domain)
+  # Replace the try+coalesce("") pattern (which can return "") with
+  # coalesce over try(..., null) to properly fall through to the next non-null value
+  lb_zone_id = coalesce(
+    try(local.nlb_compat.nlb_zone_id, null),
+    try(local.alb.alb_zone_id,      null),
+    null,
+  )
+
+  lb_fqdn    = coalesce(
+    try(local.nlb_compat.route53_record.fqdn, null),
+    try(local.alb.route53_record.fqdn,      null),
+    local.full_domain,
+  )
 
 }
 

--- a/src/remote-state.tf
+++ b/src/remote-state.tf
@@ -34,16 +34,14 @@ locals {
   lb_arn                       = try(coalesce(local.nlb_compat.nlb_arn, ""), coalesce(local.alb.alb_arn, ""), null)
   lb_name                      = try(coalesce(local.nlb_compat.nlb_name, ""), coalesce(local.alb.alb_dns_name, ""), null)
   lb_listener_http_is_redirect = try(length(local.is_nlb ? "" : local.alb.http_redirect_listener_arn) > 0, false)
-  lb_listener_https_arn        = coalesce(try(local.nlb_compat.default_listener_arn, null), try(local.alb.https_listener_arn, null), null)
+  lb_listener_https_arn        = try(coalesce(try(local.nlb_compat.default_listener_arn, null), try(local.alb.https_listener_arn, null)), null)
   lb_sg_id                     = try(local.is_nlb ? null : local.alb.security_group_id, null)
   # Replace the try+coalesce("") pattern (which can return "") with
   # coalesce over try(..., null) to properly fall through to the next non-null value
-  lb_zone_id = coalesce(
+  lb_zone_id = try(coalesce(
     try(local.nlb_compat.nlb_zone_id, null),
     try(local.alb.alb_zone_id, null),
-    "",
-  )
-  lb_zone_id_or_null = local.lb_zone_id == "" ? null : local.lb_zone_id
+  ), null)
 
   lb_fqdn = coalesce(
     try(local.nlb_compat.route53_record.fqdn, null),

--- a/src/remote-state.tf
+++ b/src/remote-state.tf
@@ -41,8 +41,9 @@ locals {
   lb_zone_id = coalesce(
     try(local.nlb_compat.nlb_zone_id, null),
     try(local.alb.alb_zone_id, null),
-    null,
+    "",
   )
+  lb_zone_id = local.lb_zone_id == "" ? null : local.lb_zone_id
 
   lb_fqdn = coalesce(
     try(local.nlb_compat.route53_record.fqdn, null),


### PR DESCRIPTION
This pull request updates several references to the Network Load Balancer (NLB) outputs in the Terraform configuration to correctly access nested fields under `nlb.nlb`. These changes ensure that the code interacts with the correct NLB resource structure, improving reliability and maintainability.

Updates to NLB output references:

* Changed all references to NLB outputs in `src/remote-state.tf` (such as `nlb_arn`, `nlb_name`, `nlb_zone_id`, `default_listener_arn`, and `route53_record.fqdn`) to use the correct nested structure `nlb.nlb.<field>` instead of `nlb.<field>`.

Load balancer configuration fixes:

* Updated the `lb_protocol` logic in `src/remote-state.tf` to use `local.nlb.nlb.is_443_enabled` for determining HTTPS protocol.
* Modified the `target_group_arn` assignment in the ECS ALB service task module in `src/main.tf` to use `local.nlb.nlb.default_target_group_arn` for NLBs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Load balancer selection now prefers an NLB-compatible output shape while preserving ALB behavior; public LB attributes resolve NLB-first with ALB fallbacks.
  - ECS service target group selection updated to use the NLB-compat path when applicable.

- Chores
  - Added a backward-compatible NLB compatibility layer and explicit null/coalesce handling for LB zone and FQDN resolution.
  - Listener ARN lists now exclude null entries to avoid spurious empty values.

- Bug Fixes
  - Vanity alias creation now requires a valid load-balancer zone ID, preventing orphaned or invalid alias resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->