### PR TITLE
feature: Add `prefix_list_ids` Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,4 @@ github/
 *.ovpn
 
 *.zip
+account-map/

--- a/src/main.tf
+++ b/src/main.tf
@@ -375,6 +375,7 @@ resource "aws_security_group_rule" "custom_sg_rules" {
   protocol                 = each.value.protocol
   cidr_blocks              = try(each.value.cidr_blocks, null)
   source_security_group_id = try(each.value.source_security_group_id, null)
+  prefix_list_ids          = try(each.value.prefix_list_ids, null)
   security_group_id        = one(module.ecs_alb_service_task[*].service_security_group_id)
 }
 

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -717,6 +717,7 @@ variable "custom_security_group_rules" {
     cidr_blocks              = optional(list(string))
     description              = optional(string)
     source_security_group_id = optional(string)
+    prefix_list_ids          = optional(list(string))
   }))
   description = "The list of custom security group rules to add to the service security group"
   default     = []


### PR DESCRIPTION
## what
This pull request adds support for specifying AWS security group rules using `prefix_list_ids` in the infrastructure configuration. This enables more flexible and secure network access control by allowing rules to reference AWS-managed prefix lists.

Security group rule enhancements:

* Updated the `aws_security_group_rule` resource in `src/main.tf` to support the `prefix_list_ids` property, allowing security group rules to reference AWS prefix lists.
* Updated the `custom_security_group_rules` variable definition in `src/variables.tf` to include an optional `prefix_list_ids` field, making it possible to configure this property via input variables.

## why
- Support `prefix_list_ids`

## references
.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Support for AWS Prefix List IDs in custom security group rules. You can now provide prefix_list_ids alongside existing options (cidr_blocks and source security group). Fully backward compatible; existing configurations continue to work unchanged.

- Chores
  - Updated ignore rules to exclude the account-map directory from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->