### PR TITLE
fix: Add idx For Security Group Map

### DIFF
--- a/src/main.tf
+++ b/src/main.tf
@@ -364,8 +364,8 @@ module "ecs_alb_service_task" {
 
 resource "aws_security_group_rule" "custom_sg_rules" {
   for_each = local.enabled && length(var.custom_security_group_rules) > 0 ? {
-    for sg_rule in var.custom_security_group_rules :
-    format("%s_%s_%s_%s", sg_rule.type, sg_rule.protocol, sg_rule.from_port, sg_rule.to_port) => sg_rule
+    for idx, sg_rule in var.custom_security_group_rules :
+    format("%s_%s_%s_%s_%d", sg_rule.type, sg_rule.protocol, sg_rule.from_port, sg_rule.to_port, idx) => sg_rule
   } : {}
 
   description              = try(each.value.description, null)


### PR DESCRIPTION
## what
This pull request makes a minor update to the way custom security group rules are keyed within the `ecs_alb_service_task` module in `src/main.tf`. The change ensures that each rule has a unique key, even if multiple rules have the same type, protocol, and port range.

* Resource key uniqueness: The key for each entry in the `aws_security_group_rule.custom_sg_rules` resource now includes the index (`idx`) in addition to type, protocol, and ports. This prevents collisions when multiple rules share the same attributes.

## why
- Avoid duplicate security group indices for different rules

## references
- Fixed #71 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Adjusted how custom security group rules are enumerated: keys now include a positional index while rule contents remain unchanged.
  * This may alter resource addresses, leading Terraform plans to show changes or replacements for existing rules.
  * No change to rule behavior or semantics for consumers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->