### PR TITLE
Bugfix: Container aliases having issue when datadog is enabled

### DIFF
--- a/src/main.tf
+++ b/src/main.tf
@@ -115,10 +115,14 @@ locals {
     name => { for key, value in zipmap(result.names, result.values) : element(reverse(split("/", key)), 0) => value }
   }
 
-  container_aliases = {
+  container_aliases_pre_dd = {
     for name, settings in var.containers :
     settings["name"] => name if local.enabled
   }
+
+  container_aliases = merge(local.container_aliases_pre_dd,
+    { for container in ["datadog-agent", "datadog-log-router"] : container => container if local.enabled && var.datadog_agent_sidecar_enabled }
+  )
 
   container_s3 = {
     for item in lookup(local.task_definition_s3, "containerDefinitions", []) :


### PR DESCRIPTION
This pull request updates how container aliases are generated in `src/main.tf` to support Datadog sidecar containers more flexibly. The main change is the introduction of a new local variable to handle pre-Datadog and Datadog-enabled scenarios, making the logic clearer and more maintainable.

**Container aliasing improvements:**

* Added `container_aliases_pre_dd` to hold aliases before considering Datadog sidecars.
* Updated `container_aliases` to merge in Datadog sidecar containers (`datadog-agent`, `datadog-log-router`) when `datadog_agent_sidecar_enabled` is true, improving conditional support for these containers.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * When the Datadog sidecar is enabled, the system now automatically includes aliases for monitoring and log-routing containers, expanding the set of recognized container aliases downstream.
  * No changes for environments where the Datadog sidecar is disabled; existing behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->