### PR TITLE
Add timeout and TLS configuration options

### DIFF
--- a/src/variables.tf
+++ b/src/variables.tf
@@ -687,6 +687,17 @@ variable "service_connect_configurations" {
       discovery_name        = optional(string, null)
       ingress_port_override = optional(number, null)
       port_name             = string
+      timeout = optional(object({
+        idle_timeout_seconds        = optional(number, null)
+        per_request_timeout_seconds = optional(number, null)
+      }), null)
+      tls = optional(object({
+        issuer_cert_authority = object({
+          aws_pca_authority_arn = string
+        })
+        kms_key  = optional(string, null)
+        role_arn = optional(string, null)
+      }), null)
     })), [])
   }))
   description = <<-EOT

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -687,17 +687,17 @@ variable "service_connect_configurations" {
       discovery_name        = optional(string, null)
       ingress_port_override = optional(number, null)
       port_name             = string
-      timeout = optional(object({
+      timeout = optional(list(object({
         idle_timeout_seconds        = optional(number, null)
         per_request_timeout_seconds = optional(number, null)
-      }), null)
-      tls = optional(object({
+      })), [])
+      tls = optional(list(object({
+        kms_key  = optional(string, null)
+        role_arn = optional(string, null)
         issuer_cert_authority = object({
           aws_pca_authority_arn = string
         })
-        kms_key  = optional(string, null)
-        role_arn = optional(string, null)
-      }), null)
+      })), [])
     })), [])
   }))
   description = <<-EOT


### PR DESCRIPTION
## what
Adds the `timeout` and `TLS` configuration to the `service_connect_configuration.service` variable.

## why
 - Aligns the `service_connect_configuration` to the [AWS resource](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_service#service_connect_configuration) as shown in the variable description.
 - dependent [`ecs-alb-service-task`](https://github.com/cloudposse/terraform-aws-ecs-alb-service-task/tree/main) component handles the addition of `timeout` and `tls` to the AWS resource.

## references
 - https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_service#service_connect_configuration


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional timeout settings for service connections, allowing control of idle and per-request timeouts.
  * Added optional TLS configuration for service connections, including certificate authority support, KMS key reference, and role-based settings; supports multiple TLS entries per service.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->