### PR TITLE
feat: add output for ECS service security group ID

### DIFF
--- a/src/outputs.tf
+++ b/src/outputs.tf
@@ -77,3 +77,8 @@ output "service_arn" {
   value       = one(module.ecs_alb_service_task[*].service_arn)
   description = "The ECS service ARN"
 }
+
+output "service_sg_id" {
+  value       = one(module.ecs_alb_service_task[*].service_security_group_id)
+  description = "The ECS service security group ID"
+}


### PR DESCRIPTION
## what
* Added the `service_sg_id`

## why
* This allows other services or dependent components to use this value to build upon this resource

## references


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Terraform output exposing the ECS service security group ID, extending available infrastructure configuration values and providing additional visibility into service networking components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->